### PR TITLE
feat(development): register sagemaker-spot-training in marketplace (#5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,8 @@
         "./skills/code-review/SKILL.md",
         "./skills/api-design/SKILL.md",
         "./skills/test-generator/SKILL.md",
-        "./skills/draw-diagram/SKILL.md"
+        "./skills/draw-diagram/SKILL.md",
+        "./skills/sagemaker-spot-training/SKILL.md"
       ]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **serverless-migration-advisor** (workflow): AWS always-on 아키텍처를 서버리스+Spot 패턴으로 이행할 때 사용하는 업스트림 어드바이저. 5-Phase 인터뷰 → 타겟 아키텍처 매핑 → 단계별 체크리스트 리포트 생성. AWS Docs 인용 의무 + serverless-autoresearch($3.94/48실험) 및 serverless-openclaw($1/월) 검증 사례 인용. 구현 how-to는 `sagemaker-spot-training` 등으로 위임. (#3)
+- development 플러그인에 `sagemaker-spot-training` 스킬 등록 (marketplace.json + plugins/development/README.md). `serverless-migration-advisor`의 Delegation 타겟으로 참조되는 스킬을 실제 설치 가능 상태로 전환. (#5)
 
 ## [0.2.0-beta] - 2026-04-07
 

--- a/plugins/development/README.md
+++ b/plugins/development/README.md
@@ -7,7 +7,8 @@
 - **TDD·품질 중심** — `code-review`와 `test-generator`가 PR 전 품질 게이트를 제공합니다.
 - **API 설계 일관성** — `api-design`이 RESTful·GraphQL의 업계 모범 사례를 일관되게 적용합니다.
 - **시각적 커뮤니케이션** — `draw-diagram`이 Draw.io(.drawio) 형식의 아키텍처·플로우차트·ERD를 직접 생성합니다(AWS 아이콘 지원).
-- **워크플로 전 단계 커버** — 4개 스킬이 설계 → 구현 → 리뷰 → 테스트 → 문서화의 흐름을 빈틈없이 연결합니다.
+- **ML 비용 최적화** — `sagemaker-spot-training`이 SageMaker Managed Spot으로 GPU 훈련 비용을 최대 90% 절감하는 실전 가이드(리전 선택·쿼터·인터럽트 처리)를 제공합니다.
+- **워크플로 전 단계 커버** — 5개 스킬이 설계 → 구현 → 리뷰 → 테스트 → 문서화의 흐름을 빈틈없이 연결합니다.
 
 ## 수록 스킬
 
@@ -17,6 +18,7 @@
 | [api-design](skills/api-design) | RESTful API·GraphQL 스키마 설계 및 리소스·엔드포인트 정의 | "사용자 CRUD API 설계해줘", "GraphQL 스키마 잡아줘" |
 | [test-generator](skills/test-generator) | 단위·통합·E2E 테스트 스위트 생성 및 커버리지 개선 | "이 함수 단위 테스트 작성해줘", "엣지 케이스 테스트 추가해줘" |
 | [draw-diagram](skills/draw-diagram) | Draw.io 아키텍처·시퀀스·플로우차트·ERD 생성 (AWS 아이콘 포함) | "시스템 아키텍처 다이어그램 그려줘", "이 흐름 플로우차트로" |
+| [sagemaker-spot-training](skills/sagemaker-spot-training) | AWS SageMaker Managed Spot Training 기반 ML 훈련 비용 최적화 가이드 | "SageMaker Spot 훈련", "GPU 비용 절감", "Spot 용량 디버깅" |
 
 ## 사용 예시
 
@@ -28,6 +30,9 @@
 
 ### 예시 3 — 아키텍처 설명 문서화
 설계 회의 결과나 기존 시스템 구조를 공유해야 할 때 `draw-diagram`으로 Draw.io 파일을 생성하면 팀원들이 바로 편집·확장할 수 있는 포맷으로 남습니다.
+
+### 예시 4 — SageMaker Managed Spot으로 ML 훈련 비용 절감
+`sagemaker-spot-training`으로 GPU 훈련 작업을 Spot 인스턴스에서 실행하는 베스트 프랙티스(리전 선택, 쿼터 확인, 인터럽트 처리)를 적용하여 on-demand 대비 최대 90% 비용 절감을 달성합니다.
 
 ## 설치
 


### PR DESCRIPTION
## Summary

Issue #5 해결: 기존에 디렉토리로만 존재하던 `sagemaker-spot-training` 스킬을 development 플러그인의 marketplace.json에 정식 등록하고 README에 노출합니다.

## Changes

- `.claude-plugin/marketplace.json` development.skills 배열에 `./skills/sagemaker-spot-training/SKILL.md` 추가
- `plugins/development/README.md` 스킬 테이블·특징 bullet·사용 예시에 반영
- CHANGELOG.md `[Unreleased]` → `### Added` 엔트리 추가

## Why

- `plugin install development@roboco-plugins` 사용자가 이 스킬을 실제로 설치·활성화할 수 있게 됨
- `serverless-migration-advisor`의 Delegation Map이 참조하는 "존재하는" 스킬이 실제로도 존재 보장
- root README와 marketplace.json·plugin README 사이의 불일치 해소

## Closes

- #5

## Test plan

- [x] `npm test` 전부 green
- [ ] `/plugin install development@roboco-plugins` 설치 후 `/sagemaker-spot-training` 호출 확인
- [ ] `serverless-migration-advisor`에서 Tier 1 시나리오 실행 시 delegation이 이 스킬로 연결되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)