### PR TITLE
docs(spec): align REQUIRED_FM in llm-wiki SPEC with implementation (#10)

### DIFF
--- a/issues/8-llm-wiki/SPEC.md
+++ b/issues/8-llm-wiki/SPEC.md
@@ -187,7 +187,7 @@ argument-hint: [init|ingest|query|lint|sync|export|qmd-index|lancedb-sync] [args
 - 검사 항목:
   - `[[wiki-link]]` 대상 존재 여부
   - 고아 페이지 (INDEX.md에서 링크되지 않음)
-  - frontmatter 필수 필드 (`title`, `created`, `updated`, `status`)
+  - frontmatter 필수 필드 (`title`, `updated`) — `created`, `status`는 권장(필수 아님)
   - confidence 신뢰도 낮은 페이지 플래그
 - 출력: 표준출력 리포트 + exit code (0=green, 1=issues)
 


### PR DESCRIPTION
## Summary

- Issue #10의 SPEC ↔ lint/SKILL 드리프트 해소 (옵션 A)
- `issues/8-llm-wiki/SPEC.md` §6.3 필수 필드: 4개(`title/created/updated/status`) → 2개(`title/updated`)로 축소
- `created`, `status`는 권장 항목으로 명시

## Why this approach

- `lint_wiki.py:17` 의 `REQUIRED_FM = ['title', 'updated']` 가 실제 동작
- `SKILL.md` 가 사용자 계약이며 이미 2개로 명시 — SPEC만 드리프트 상태였음
- 기존 위키 페이지의 강제 마이그레이션 회피

## Test plan

- [x] `npm test` — 203 tests pass
- [x] SPEC §6.3 ↔ `lint_wiki.py` REQUIRED_FM ↔ SKILL.md §lint 표현 일치 확인

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)